### PR TITLE
Update DellCommandUpdate.ps1

### DIFF
--- a/scripts/DellCommandUpdate.ps1
+++ b/scripts/DellCommandUpdate.ps1
@@ -249,7 +249,7 @@ function Install-DotNetDesktopRuntime {
   }
   
   $LatestDotNet = Get-LatestDotNetDesktopRuntime
-  $CurrentVersion = (Get-InstalledApps -DisplayName 'Microsoft Windows Desktop Runtime').BundleVersion | Where-Object { $_ -like '8.*' }
+  $CurrentVersion = (Get-InstalledApps -DisplayName 'Microsoft Windows Desktop Runtime*(x64)').BundleVersion | Where-Object { $_ -like '8.*' }
   Write-Output "`n.NET 8.0 Desktop Runtime Info`n-----"
   Write-Output "Installed: $CurrentVersion"
   Write-Output "Latest: $($LatestDotNet.Version)"


### PR DESCRIPTION
Forces .Net to be checked against 64 Bit version. DELL Command update is only available as 64 Bit but .Net could be installed as 32 Bit. This enforces to check 64. Bit of .Net. Having 32 Bit will not download the 64 bit and therefore the dependency for DELL Command update 64 bit will fail with error code 4. This fixes it.